### PR TITLE
Fix dividend and price when a different symbol is used

### DIFF
--- a/Sources/SwiftBeanCountWealthsimpleMapper/LedgerLookup.swift
+++ b/Sources/SwiftBeanCountWealthsimpleMapper/LedgerLookup.swift
@@ -92,7 +92,7 @@ struct LedgerLookup {
         case let .transactionType(transactionType):
             key = "\(MetaDataKeys.prefix)\("\(transactionType)".camelCaseToKebabCase())"
         case let .dividend(dividendSymbol):
-            key = "\(MetaDataKeys.dividendPrefix)\(dividendSymbol)"
+            key = "\(MetaDataKeys.dividendPrefix)\(try commoditySymbol(for: dividendSymbol))"
         case .contributionRoom:
             key = MetaDataKeys.contributionRoom
         case .rounding:

--- a/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleLedgerMapper.swift
+++ b/Sources/SwiftBeanCountWealthsimpleMapper/WealthsimpleLedgerMapper.swift
@@ -204,7 +204,7 @@ public struct WealthsimpleLedgerMapper {
                     amount: Amount(for: transaction.quantity, in: try lookup.commoditySymbol(for: transaction.symbol)),
                     cost: try Cost(amount: transaction.marketPrice, date: nil, label: nil))
         ])
-        return (try Price(date: transaction.processDate, commoditySymbol: transaction.symbol, amount: transaction.marketPrice), result)
+        return (try Price(date: transaction.processDate, commoditySymbol: lookup.commoditySymbol(for: transaction.symbol), amount: transaction.marketPrice), result)
     }
 
     private func mapSell(_ transaction: WTransaction, in account: WAccount) throws -> (Price, STransaction) {
@@ -215,7 +215,7 @@ public struct WealthsimpleLedgerMapper {
                     price: transaction.marketPrice,
                     cost: try Cost(amount: nil, date: nil, label: nil))
         ])
-        return (try Price(date: transaction.processDate, commoditySymbol: transaction.symbol, amount: transaction.marketPrice), result)
+        return (try Price(date: transaction.processDate, commoditySymbol: lookup.commoditySymbol(for: transaction.symbol), amount: transaction.marketPrice), result)
     }
 
     private func mapTransfer(_ transaction: WTransaction, in account: WAccount, accountTypes: [SwiftBeanCountModel.AccountType], payee: String = "") throws -> STransaction {

--- a/Tests/SwiftBeanCountWealthsimpleMapperTests/LedgerLookupTests.swift
+++ b/Tests/SwiftBeanCountWealthsimpleMapperTests/LedgerLookupTests.swift
@@ -105,6 +105,7 @@ final class LedgerLookupTests: XCTestCase {
         name = try AccountName("Income:Test")
         let symbol = "XGRO"
         try ledger.add(Account(name: name, metaData: ["\(MetaDataKeys.dividendPrefix)\(symbol)": number, "\(MetaDataKeys.prefix)giveaway-bonus": number]))
+        try ledger.add(Commodity(symbol: symbol))
         ledgerLookup = LedgerLookup(ledger)
         XCTAssertEqual(try ledgerLookup.ledgerAccountName(for: .dividend(symbol), in: TestAccount(number: number), ofType: [.income] ), name)
         XCTAssertEqual(try ledgerLookup.ledgerAccountName(for: .transactionType(.giveawayBonus), in: TestAccount(number: number), ofType: [.income] ), name)


### PR DESCRIPTION
If a wealthsimple symbol was mapped to a commodity with a different name, the dividend account lookup and price import were using the wrong symbol.